### PR TITLE
Ignore the vetur js formatter

### DIFF
--- a/city-hunt.code-workspace
+++ b/city-hunt.code-workspace
@@ -20,6 +20,7 @@
 	},
 	"settings": {
 		"vetur.validation.template": true,
+		"vetur.format.defaultFormatter.js": "none",
 		"npm.packageManager": "npm",
 		"eslint.validate": [
 			{


### PR DESCRIPTION
Add the "vetur.format.defaultFormatter.js": "none" into city-hunt.code-workspace