### PR TITLE
Fix/locate component error display

### DIFF
--- a/src/components/Locate.vue
+++ b/src/components/Locate.vue
@@ -10,6 +10,7 @@
     </div>
     <v-progress-circular v-else class="ma-5" size="70" indeterminate color="primary"></v-progress-circular>
     <p class="message" v-text="message"></p>
+    <p class="mx-5 text-xs-center" v-text="errMsg"></p>
   </v-layout>
 </template>
 
@@ -32,7 +33,8 @@ export default {
   },
   data () {
     return {
-      status: STATUS.NEVER
+      status: STATUS.NEVER,
+      errMsg: ''
     }
   },
   computed: {
@@ -55,7 +57,7 @@ export default {
         case STATUS.PROCESSING:
           return '定位中...'
         case STATUS.CHECKED_WRONG:
-          return '你確定是這裡？'
+          return '確定是這裡嗎？請再想想喔'
         case STATUS.CHECKED_CORRECT:
           return `你到了正確的地方，請點擊頁面！`
         default:
@@ -66,6 +68,7 @@ export default {
   methods: {
     async locate () {
       try {
+        this.errMsg = ''
         this.status = STATUS.PROCESSING
         const locationA = await getSelfLocation()
         const locationB = this.target
@@ -73,6 +76,7 @@ export default {
         this.status = distance <= 50 ? STATUS.CHECKED_CORRECT : STATUS.CHECKED_WRONG
         this.$emit('locate', distance <= 50)
       } catch (err) {
+        this.errMsg = err.message
         this.status = STATUS.ERROR
         this.$emit('locate', false)
       }

--- a/src/utils/location.js
+++ b/src/utils/location.js
@@ -13,15 +13,10 @@ function getCurrentPosition () {
  */
 export async function getSelfLocation () {
   if ('geolocation' in navigator) {
-    const permissionStatus = await navigator.permissions.query({ name: 'geolocation' })
-    if (permissionStatus.state === 'denied') {
-      throw Error('Permission denied')
-    } else {
-      const { coords } = await getCurrentPosition()
-      return {
-        lat: coords.latitude,
-        lng: coords.longitude
-      }
+    const { coords } = await getCurrentPosition()
+    return {
+      lat: coords.latitude,
+      lng: coords.longitude
     }
   } else {
     throw Error('Geolocation is not available')


### PR DESCRIPTION
1. 修正定位錯誤訊息的顯示，並將例外訊息印出。

2. 移除提前的權限檢查，ios上沒有這個 API，直接交由 getCurrentLocation 處理。